### PR TITLE
 feat(local-file-player): when selecting new files, add them to playlist, not replace it #123 

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,8 +1,7 @@
 1. Pull `src/_locales` from the Weblate repo, commit `.gitmodules`.
 2. Add new contributors to `src/_locales/LICENSE_NOTICES`. To make sure you didn't miss anyone, check if `git shortlog --summary --email | wc -l` outputs a number that is 1 smaller than the number of lines in the coppyright notice (to account for Anonymous).
-3. If new languages were added, check if their language code works alright in the browsers.
-4. Bump version in `src/manifest.json`
-5. Publish
+3. Bump version in `src/manifest.json`
+4. Publish
     * Chrome Web Store
 
       Nothing special currently

--- a/src/entry-points/local-file-player/App.svelte
+++ b/src/entry-points/local-file-player/App.svelte
@@ -16,16 +16,17 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/licenses/>.
 -->
-
 <script lang="ts">
-  import { tick, onMount } from 'svelte';
+  import { tick, onMount } from "svelte";
   // TODO get rid of svelte?
-  import { getMessage } from '@/helpers';
+  import { getMessage } from "@/helpers";
 
-  const defaultDocumentTitle = 'Jump Cutter: local video player'; // TODO translate?
+  const defaultDocumentTitle = "Jump Cutter: local video player"; // TODO translate?
   document.title = defaultDocumentTitle;
 
-  type HTMLInputElementTypeFile = HTMLInputElement & { files: NonNullable<HTMLInputElement['files']> };
+  type HTMLInputElementTypeFile = HTMLInputElement & {
+    files: NonNullable<HTMLInputElement["files"]>;
+  };
   let inputEl: HTMLInputElementTypeFile;
   let videoEl: HTMLVideoElement;
   let objectURL: ReturnType<typeof URL.createObjectURL> | undefined;
@@ -50,11 +51,16 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
 
     playFile(0);
   }
+
+  async function onDeleteFile(fileName: string) {
+    files = files.filter((file) => file.name !== fileName);
+  }
+
   async function playFile(ind: number) {
     currFileInd = ind;
     const file = inputEl.files[ind];
     // TODO handle `!video.canPlayType(file.type)`?
-    document.title = file.name + ' – Jump Cutter';
+    document.title = file.name + " – Jump Cutter";
     // For better performance. https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#Memory_management
     objectURL && URL.revokeObjectURL(objectURL);
     objectURL = URL.createObjectURL(file);
@@ -66,28 +72,29 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
   }
 
   onMount(() => {
-    videoEl.addEventListener('ended', async () => {
-      // TODO `if (loop)` `const nextFileInd = (currFileInd + 1) % inputEl.files.length;`
-      const nextFileInd = currFileInd + 1;
-      if (nextFileInd < inputEl.files.length) {
-        // TODO `if (autoplay)`
-        playFile(nextFileInd);
-      }
-    }, { passive: true });
+    videoEl.addEventListener(
+      "ended",
+      async () => {
+        // TODO `if (loop)` `const nextFileInd = (currFileInd + 1) % inputEl.files.length;`
+        const nextFileInd = currFileInd + 1;
+        if (nextFileInd < inputEl.files.length) {
+          // TODO `if (autoplay)`
+          playFile(nextFileInd);
+        }
+      },
+      { passive: true }
+    );
   });
-
 </script>
 
 <!-- TODO but can we add a way to add captions? -->
 <!-- svelte-ignore a11y-media-has-caption -->
 <div class="video-and-file-input">
-  <div
-    style="display: flex; flex-wrap: wrap;"
-  >
+  <div style="display: flex; flex-wrap: wrap;">
     <video
       bind:this={videoEl}
       controls
-      style={objectURL ? '' : 'display: none; '}
+      style={objectURL ? "" : "display: none; "}
     />
     <!-- <label>
       <input
@@ -101,12 +108,15 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
         <!-- {#each inputEl?.files ?? [] as file, ind} -->
         {#each files as file, ind}
           <li>
-            <button
-              on:click={() => playFile(ind)}
-              disabled={ind === currFileInd}
-            >
-              {file.name}
-            </button>
+            <div class="file-wrapper">
+              <button
+                on:click={() => playFile(ind)}
+                disabled={ind === currFileInd}
+              >
+                {file.name}
+              </button>
+              <button on:click={() => onDeleteFile(file.name)}> ❌ </button>
+            </div>
           </li>
         {/each}
       </ol>
@@ -122,10 +132,13 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
       multiple
     />
     <div class="input-box-content">
-      <p style="text-align: center; margin: 1rem; white-space: pre-line;">{getMessage('fileInputLabel')}</p>
+      <p style="text-align: center; margin: 1rem; white-space: pre-line;">
+        {getMessage("fileInputLabel")}
+      </p>
     </div>
   </div>
 </div>
+
 <style>
   @media (prefers-color-scheme: dark) {
     :global(body) {
@@ -163,6 +176,10 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     display: flex;
     flex-direction: column;
   }
+  .file-wrapper {
+    display: flex;
+    flex-direction: row;
+  }
 
   /* The input has `opacity: 0`, so this is to replicate its behavior. */
   .video-input-wrapper:focus-within {
@@ -184,13 +201,13 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     align-items: center;
     font-size: 3rem;
     color: #555;
-    background:rgba(0, 255, 0, 0.3);
+    background: rgba(0, 255, 0, 0.3);
     border: 0.25rem dashed gray;
   }
   @media (prefers-color-scheme: dark) {
     .input-box-content {
       color: #aaa;
-      background:rgba(0, 255, 0, 0.2);
+      background: rgba(0, 255, 0, 0.2);
       border-color: #111;
     }
   }

--- a/src/entry-points/local-file-player/App.svelte
+++ b/src/entry-points/local-file-player/App.svelte
@@ -36,8 +36,6 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
   // Need this because Svelte's reactivity doesn't appear to work properly with `FileList`.
   let files: File[] = [];
   async function onInputChange() {
-    files = [];
-
     numFiles = inputEl.files.length;
     if (numFiles <= 0) {
       // In case it was un-selected (I think that's the only case when it can happen).
@@ -46,7 +44,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     }
 
     for (const file of inputEl.files) {
-      files.push(file);
+      files = [...files, file];
     }
 
     playFile(0);


### PR DESCRIPTION
1. Added Remove button for playlist.
2. New file can add to play list instead of replace it. (reasons: `onInputChange()` function redefine the files array. Also, svelte have to use spread operator to reassign variable [stackoverflow solution](https://stackoverflow.com/questions/69791435/svelte-list-wont-update-when-i-add-to-an-array)

![remove button   add item into playlist](https://user-images.githubusercontent.com/51984388/210814622-0d7c62f5-ce07-4b1a-9227-29cdab973274.gif)
