### PR TITLE
improvement(settings): Set a non-serif font family

### DIFF
--- a/src/entry-points/options/App.svelte
+++ b/src/entry-points/options/App.svelte
@@ -628,6 +628,8 @@ main {
   max-width: var(--content-max-width);
   margin-right: auto;
   margin-left: auto;
+  /* Needed for Firefox, by deafult it renders the settings page with a serif font */
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 footer {
   padding: 0 var(--main-padding);


### PR DESCRIPTION
I've noticed that unlike Chromium, Firefox's default settings make the settings page have a weird Serif font. I've fixed this by explicitly setting a font-family