### PR TITLE
improvement(settings): Change layout to be more readable

### DIFF
--- a/src/entry-points/options/components/CheckboxField.svelte
+++ b/src/entry-points/options/components/CheckboxField.svelte
@@ -1,5 +1,6 @@
 <!--
 Copyright (C) 2020, 2021, 2022  WofWca <wofwca@protonmail.com>
+Copyright (C) 2023  jakubiakdev
 
 This file is part of Jump Cutter Browser Extension.
 
@@ -43,10 +44,10 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     border-bottom: 1px gray solid;
     padding: 0.5rem;
   }
-  
+
   label {
     display: grid;
-    grid-template-columns: auto auto; 
+    grid-template-columns: auto auto;
   }
   input {
     justify-self: right;

--- a/src/entry-points/options/components/CheckboxField.svelte
+++ b/src/entry-points/options/components/CheckboxField.svelte
@@ -41,8 +41,10 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
 <style>
   div {
     margin: 0.75rem 0;
-    border-bottom: 1px gray solid;
     padding: 0.5rem;
+  }
+  div:not(:last-child) {
+    border-bottom: 1px gray solid;
   }
 
   label {

--- a/src/entry-points/options/components/CheckboxField.svelte
+++ b/src/entry-points/options/components/CheckboxField.svelte
@@ -26,19 +26,29 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
 </script>
 
 <!-- Wrapper div so consecutive checkboxes are displayed on top of each other. -->
-<div style="margin: 0.75rem 0;">
+<div>
   <label>
+    {label}
     <input
       type="checkbox"
       {...$$restProps}
       bind:checked
-    > {label}
+    >
   </label>
 </div>
 
 <style>
+  div {
+    margin: 0.75rem 0;
+    border-bottom: 1px gray solid;
+    padding: 0.5rem;
+  }
+  
+  label {
+    display: grid;
+    grid-template-columns: auto auto; 
+  }
   input {
-    /* So emojis aren't so close to the checkbox so they don't look too confusing together */
-    margin-right: 0.4rem;
+    justify-self: right;
   }
 </style>

--- a/src/entry-points/options/components/InputFieldBase.svelte
+++ b/src/entry-points/options/components/InputFieldBase.svelte
@@ -1,5 +1,6 @@
 <!--
 Copyright (C) 2020, 2021, 2022  WofWca <wofwca@protonmail.com>
+Copyright (C) 2023  jakubiakdev
 
 This file is part of Jump Cutter Browser Extension.
 
@@ -30,7 +31,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
   <label
     for={id}
   >{label}</label>
-  <div class="slotContainer">
+  <div class="slot-container">
     <slot {id}></slot>
   </div>
 </div>
@@ -41,15 +42,15 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     border-bottom: 1px gray solid;
     padding: 0.5rem;
     display: grid;
-    grid-template-columns: auto auto; 
+    grid-template-columns: auto auto;
   }
-  
+
   label {
     padding-bottom: 0.125rem;
     display: inline-block;
   }
 
-  .slotContainer {
+  .slot-container {
     justify-self: right;
   }
 </style>

--- a/src/entry-points/options/components/InputFieldBase.svelte
+++ b/src/entry-points/options/components/InputFieldBase.svelte
@@ -39,10 +39,12 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
 <style>
   .container {
     margin: 0.75rem 0;
-    border-bottom: 1px gray solid;
     padding: 0.5rem;
     display: grid;
     grid-template-columns: auto auto;
+  }
+  .container:not(:last-child) {
+    border-bottom: 1px gray solid;
   }
 
   label {

--- a/src/entry-points/options/components/InputFieldBase.svelte
+++ b/src/entry-points/options/components/InputFieldBase.svelte
@@ -26,12 +26,30 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
   const id = Math.random().toString();
 </script>
 
-<div style="margin: 0.75rem 0;">
+<div class="container">
   <label
-    style="padding-bottom: 0.125rem; display: inline-block;"
     for={id}
   >{label}</label>
-  <div>
+  <div class="slotContainer">
     <slot {id}></slot>
   </div>
 </div>
+
+<style>
+  .container {
+    margin: 0.75rem 0;
+    border-bottom: 1px gray solid;
+    padding: 0.5rem;
+    display: grid;
+    grid-template-columns: auto auto; 
+  }
+  
+  label {
+    padding-bottom: 0.125rem;
+    display: inline-block;
+  }
+
+  .slotContainer {
+    justify-self: right;
+  }
+</style>


### PR DESCRIPTION
This might be a matter of personal opinion, but when I downloaded this extension today, the settings page was very difficult to read. I hope by adding a divider between options, and separating checkboxes/selects the settings page will be more readable at a glance.

Feel free to suggest changes about this new layout