### PR TITLE
improvement: don't clone MediaSources when not needed

### DIFF
--- a/src/entry-points/content/cloneMediaSources/main-for-extension-world.ts
+++ b/src/entry-points/content/cloneMediaSources/main-for-extension-world.ts
@@ -32,15 +32,6 @@ sendBridgeElement();
 // TODO fix: _this_ script runs at `document_start` (see `manifest.json`), but I'm not sure whether
 // the script we inject below also runs before other scripts. Manifest V3 with its
 // `content_scripts.world` should fix it.
-//
-// TODO fix: add an option to disable the execution of this script. Because of it, now
-// in Chromium if the user has "Site access" for this extension set to "activate on click",
-// the browser will prompt the user to reload the page after they do click on it.
-// Also it slows down page load, and introduces potential side effects because it mutates
-// built-in objects.
-// `scripting.registerContentScripts()` or `contentScripts.register()` is the way.
-// Or maybe add a way to execute it on `document_idle` as well, in case the target websites work
-// ok that way.
 const scriptEl = document.createElement('script');
 scriptEl.src = browserOrChrome.runtime.getURL('content/cloneMediaSources-for-page-world.js');
 // TODO perf: consider adding `defer`, `async`, etc.

--- a/src/manifest_base.json
+++ b/src/manifest_base.json
@@ -2,7 +2,7 @@
   "name": "Jump Cutter",
   "version": "1.27.0",
   "description": "__MSG_extensionDescription__",
-  "permissions": ["storage"],
+  "permissions": ["storage", "scripting"],
   "content_security_policy": {
     "extension_pages": "default-src 'none'; script-src 'self'; img-src 'self'; style-src 'unsafe-inline';"
   },
@@ -20,15 +20,9 @@
       "all_frames": true,
       "run_at": "document_idle",
       "match_about_blank": true
-    },
-    {
-      "matches": ["http://*/*", "https://*/*"],
-      "js": ["content/cloneMediaSources-for-extension-world.js"],
-      "all_frames": true,
-      "run_at": "document_start",
-      "match_about_blank": true
     }
   ],
+  "host_permissions": ["http://*/*", "https://*/*"],
   "web_accessible_resources": [
     {
       "resources": [


### PR DESCRIPTION
i.e. when the experimental algorithm or the whole extension is disabled

This has 3 benefits:
- performance
- avoids breaking websites
- Before this commit, in Chromium if the user has "Site access" for
  this extension set to "activate on click", the browser would
  prompt the user to reload the page after they do click on it,
  even when the experimental algorithm is actually disabled
  and the reload is not actually needed

However, this change has side-effects: now, after enabling
the experimental algorithm on websites
that rely on MediaSource cloning,
the page needs to be reloaded, but there is no clear indication
of it now.

The motivation for this is to finally release the version that
includes the new MediaSource cloning algorithm (https://github.com/WofWca/jumpcutter/commit/e9daff122f12263a50fb1c4a10e4b13c7fd190cf)
to Chromium (where the majority of users are)
in a safer way, so that it can be disabled and can't break websites,
e.g. by overriding `canConstructInDedicatedWorker`
(see src/entry-points/content/cloneMediaSources/lib.ts#L460).

Although, based on my testing, the algorithm appears to be quite
stable, especially with the recent fixes, at least on YouTube.

About the changes to manifest.json:
The new `host_permissions` _won't_ trigger a permission warning
upon update, at least on Chromium. I tested this, using this guide:
https://developer.chrome.com/docs/extensions/develop/concepts/permission-warnings#view_warnings
Did not test on Gecko (Firefox).
This, I suspect, is because the
"Read and change all your data on all websites."
permission is already granted thanks to `content_scripts.matches`
https://developer.chrome.com/docs/extensions/reference/permissions-list

The "scripting" permission doesn't trigger a warning at all

The docs say that for `scripting.registerContentScripts()` to work
we need _either_ "host_permissions" or the "activeTab" permission.
"activeTab" is not enough, because this way the script is only
injected on pages on which the user has interacted with the extension,
e.g. opened the popup, which means they would need to do this
before the original `MediaSource` is created,
or reload the page.

Co-authored-by: WofWca
Commit message by WofWca