### PR TITLE
Add show estimated remaining video duration feature

### DIFF
--- a/src/entry-points/content/AllMediaElementsController.ts
+++ b/src/entry-points/content/AllMediaElementsController.ts
@@ -57,7 +57,11 @@ export type TelemetryMessage =
     elementLikelyCorsRestricted: boolean,
     elementCurrentSrc?: string,
     createMediaElementSourceCalledForElement: boolean,
-    elementRemainingDuration: number,
+     /**
+     * Remember that this could be `Infinity` for live streams,
+     * and if `.duration` is otherwise unknown.
+     */
+    elementRemainingIntrinsicDuration: number,
   };
 
 function executeNonSettingsActions(
@@ -331,7 +335,7 @@ export default class AllMediaElementsController {
             elementCurrentSrc: elementLikelyCorsRestricted ? this.activeMediaElement.currentSrc : undefined,
             // TODO check if the map lookup is too slow to do it several times per second.
             createMediaElementSourceCalledForElement: !!mediaElementSourcesMap.get(this.activeMediaElement),
-            elementRemainingDuration: this.activeMediaElement.duration-this.activeMediaElement.currentTime,
+            elementRemainingIntrinsicDuration: this.activeMediaElement.duration-this.activeMediaElement.currentTime,
           };
           port.postMessage(telemetryMessage);
         };

--- a/src/entry-points/content/AllMediaElementsController.ts
+++ b/src/entry-points/content/AllMediaElementsController.ts
@@ -335,7 +335,7 @@ export default class AllMediaElementsController {
             elementCurrentSrc: elementLikelyCorsRestricted ? this.activeMediaElement.currentSrc : undefined,
             // TODO check if the map lookup is too slow to do it several times per second.
             createMediaElementSourceCalledForElement: !!mediaElementSourcesMap.get(this.activeMediaElement),
-            elementRemainingIntrinsicDuration: this.activeMediaElement.duration-this.activeMediaElement.currentTime,
+            elementRemainingIntrinsicDuration: this.activeMediaElement.duration - this.activeMediaElement.currentTime,
           };
           port.postMessage(telemetryMessage);
         };

--- a/src/entry-points/content/AllMediaElementsController.ts
+++ b/src/entry-points/content/AllMediaElementsController.ts
@@ -57,6 +57,7 @@ export type TelemetryMessage =
     elementLikelyCorsRestricted: boolean,
     elementCurrentSrc?: string,
     createMediaElementSourceCalledForElement: boolean,
+    elementRemainingDuration: number,
   };
 
 function executeNonSettingsActions(
@@ -330,6 +331,7 @@ export default class AllMediaElementsController {
             elementCurrentSrc: elementLikelyCorsRestricted ? this.activeMediaElement.currentSrc : undefined,
             // TODO check if the map lookup is too slow to do it several times per second.
             createMediaElementSourceCalledForElement: !!mediaElementSourcesMap.get(this.activeMediaElement),
+            elementRemainingDuration: this.activeMediaElement.duration-this.activeMediaElement.currentTime,
           };
           port.postMessage(telemetryMessage);
         };

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -370,10 +370,10 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     return min < x && x < max;
   }
   $: timeSavedPlaybackRateEquivalents = getTimeSavedPlaybackRateEquivalents(latestTelemetryRecord);
-  $: estimatedRemainingDuration = settingsLoaded &&
-                                  r?.elementRemainingIntrinsicDuration &&
-                                  r?.elementRemainingIntrinsicDuration != Infinity
-    ? mmSs((r?.elementRemainingIntrinsicDuration / timeSavedPlaybackRateEquivalents[0]) / settings?.soundedSpeed)
+  $: estimatedRemainingDuration = settings &&
+                                  r?.elementRemainingIntrinsicDuration != undefined &&
+                                  r.elementRemainingIntrinsicDuration < Infinity
+    ? (r.elementRemainingIntrinsicDuration / timeSavedPlaybackRateEquivalents[0]) / settings.soundedSpeed
     : undefined;
   $: timeSavedPlaybackRateEquivalentsAreDifferent =
     // Can't compare `timeSavedPlaybackRateEquivalents[0]` and `[1]` because due to rounding they can
@@ -572,11 +572,15 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
             {/if}
           </ol>
 
-          {#if estimatedRemainingDuration}
+          {#if estimatedRemainingDuration &&
+               // 10.000 hour sanity check
+               estimatedRemainingDuration < (10000*60*60)
+          }
               <p
                 style="margin-bottom: 0.25rem;"
-              >{getMessage('estimatedRemainingDuration')}<br>
-                  <li>{estimatedRemainingDuration}</li>
+              >
+              {getMessage('estimatedRemainingDuration')}<br>
+              {mmSs(estimatedRemainingDuration)}
               </p>
           {/if}
 

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -393,7 +393,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     // same (although for a brief moment), despite the soundedSpeed actually never being `=== 1`.
     || (settings && settings.soundedSpeed !== 1);
   // TODO DRY
-    $: timeSavedOnlyOneNumberIsShown =
+  $: timeSavedOnlyOneNumberIsShown =
     !timeSavedPlaybackRateEquivalentsAreDifferent
     && settings?.timeSavedAveragingMethod === 'exponential';
 
@@ -552,10 +552,9 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
               <span>{getMessage('overTheLast', mmSs(settings.timeSavedAveragingWindowLength))}.</span>
             {/if}
           </p>
-            {#if !timeSavedOnlyOneNumberIsShown}
-                <p>{getMessage('numbersMeanings')}</p>
-            {/if}
-        <p>{getMessage('numbersMeanings')}</p>
+          {#if !timeSavedOnlyOneNumberIsShown}
+              <p>{getMessage('numbersMeanings')}</p>
+          {/if}
           <ol style="padding-left: 2ch; margin-bottom: 0.25rem">
             <li
               style={timeSavedOnlyOneNumberIsShown ? 'list-style:none;' : ''}

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -553,7 +553,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
             {/if}
           </p>
           {#if !timeSavedOnlyOneNumberIsShown}
-              <p>{getMessage('numbersMeanings')}</p>
+            <p>{getMessage('numbersMeanings')}</p>
           {/if}
           <ol style="padding-left: 2ch; margin-bottom: 0.25rem">
             <li

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -573,7 +573,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
           </ol>
 
           {#if estimatedRemainingDuration != undefined &&
-               // 10.000 hour sanity check
+               // 10,000 hour sanity check
                estimatedRemainingDuration < (10000*60*60)
           }
               <p

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -572,7 +572,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
             {/if}
           </ol>
 
-          {#if estimatedRemainingDuration &&
+          {#if estimatedRemainingDuration != undefined &&
                // 10.000 hour sanity check
                estimatedRemainingDuration < (10000*60*60)
           }

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -367,6 +367,7 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     return min < x && x < max;
   }
   $: timeSavedPlaybackRateEquivalents = getTimeSavedPlaybackRateEquivalents(latestTelemetryRecord);
+  $: estimatedRemainingDuration = mmSs((r?.elementRemainingDuration / timeSavedPlaybackRateEquivalents[0]) / settings?.soundedSpeed || 0);
   $: timeSavedPlaybackRateEquivalentsAreDifferent =
     // Can't compare `timeSavedPlaybackRateEquivalents[0]` and `[1]` because due to rounding they can
     // jump between being the same and being different even if you don't change soundedSpeed.
@@ -385,9 +386,6 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     // same (although for a brief moment), despite the soundedSpeed actually never being `=== 1`.
     || (settings && settings.soundedSpeed !== 1);
   // TODO DRY
-  $: timeSavedOnlyOneNumberIsShown =
-    !timeSavedPlaybackRateEquivalentsAreDifferent
-    && settings?.timeSavedAveragingMethod === 'exponential';
 
   function onUseExperimentalAlgorithmInput(e: Event) {
     const newControllerType = (e.target as HTMLInputElement).checked
@@ -503,13 +501,12 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
               <span>{getMessage('overTheLast', mmSs(settings.timeSavedAveragingWindowLength))}.</span>
             {/if}
           </p>
-          {#if !timeSavedOnlyOneNumberIsShown}
-            <p>{getMessage('numbersMeanings')}</p>
-          {/if}
+        <p>{getMessage('numbersMeanings')}</p>
           <ol style="padding-left: 2ch; margin-bottom: 0.25rem">
-            <li
-              style={timeSavedOnlyOneNumberIsShown ? 'list-style:none;' : ''}
-            >{timeSavedPlaybackRateEquivalents[0]} – {getMessage('timeSavedComparedToSounded')}</li>
+            <li>{timeSavedPlaybackRateEquivalents[0]} – {getMessage('timeSavedComparedToSounded')}</li>
+            {#if estimatedRemainingDuration}
+                <li>{estimatedRemainingDuration} – {getMessage('estimatedRemainingDuration')}</li>
+            {/if}
             {#if settings.timeSavedAveragingMethod !== 'exponential'}
               <li>{timeSavedComparedToSoundedSpeedAbs} – {getMessage('timeSavedComparedToSoundedAbs')}</li>
               <li>{wouldHaveLastedIfSpeedWasSounded} – {getMessage('wouldHaveLastedIfSpeedWasSounded')}</li>

--- a/src/entry-points/popup/App.svelte
+++ b/src/entry-points/popup/App.svelte
@@ -370,7 +370,11 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     return min < x && x < max;
   }
   $: timeSavedPlaybackRateEquivalents = getTimeSavedPlaybackRateEquivalents(latestTelemetryRecord);
-  $: estimatedRemainingDuration = mmSs((r?.elementRemainingDuration / timeSavedPlaybackRateEquivalents[0]) / settings?.soundedSpeed || 0);
+  $: estimatedRemainingDuration = settingsLoaded &&
+                                  r?.elementRemainingIntrinsicDuration &&
+                                  r?.elementRemainingIntrinsicDuration != Infinity
+    ? mmSs((r?.elementRemainingIntrinsicDuration / timeSavedPlaybackRateEquivalents[0]) / settings?.soundedSpeed)
+    : undefined;
   $: timeSavedPlaybackRateEquivalentsAreDifferent =
     // Can't compare `timeSavedPlaybackRateEquivalents[0]` and `[1]` because due to rounding they can
     // jump between being the same and being different even if you don't change soundedSpeed.
@@ -389,6 +393,9 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
     // same (although for a brief moment), despite the soundedSpeed actually never being `=== 1`.
     || (settings && settings.soundedSpeed !== 1);
   // TODO DRY
+    $: timeSavedOnlyOneNumberIsShown =
+    !timeSavedPlaybackRateEquivalentsAreDifferent
+    && settings?.timeSavedAveragingMethod === 'exponential';
 
   function onUseExperimentalAlgorithmInput(e: Event) {
     const newControllerType = (e.target as HTMLInputElement).checked
@@ -545,12 +552,14 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
               <span>{getMessage('overTheLast', mmSs(settings.timeSavedAveragingWindowLength))}.</span>
             {/if}
           </p>
+            {#if !timeSavedOnlyOneNumberIsShown}
+                <p>{getMessage('numbersMeanings')}</p>
+            {/if}
         <p>{getMessage('numbersMeanings')}</p>
           <ol style="padding-left: 2ch; margin-bottom: 0.25rem">
-            <li>{timeSavedPlaybackRateEquivalents[0]} – {getMessage('timeSavedComparedToSounded')}</li>
-            {#if estimatedRemainingDuration}
-                <li>{estimatedRemainingDuration} – {getMessage('estimatedRemainingDuration')}</li>
-            {/if}
+            <li
+              style={timeSavedOnlyOneNumberIsShown ? 'list-style:none;' : ''}
+            >{timeSavedPlaybackRateEquivalents[0]} – {getMessage('timeSavedComparedToSounded')}</li>
             {#if settings.timeSavedAveragingMethod !== 'exponential'}
               <li>{timeSavedComparedToSoundedSpeedAbs} – {getMessage('timeSavedComparedToSoundedAbs')}</li>
               <li>{wouldHaveLastedIfSpeedWasSounded} – {getMessage('wouldHaveLastedIfSpeedWasSounded')}</li>
@@ -563,6 +572,15 @@ along with Jump Cutter Browser Extension.  If not, see <https://www.gnu.org/lice
               {/if}
             {/if}
           </ol>
+
+          {#if estimatedRemainingDuration}
+              <p
+                style="margin-bottom: 0.25rem;"
+              >{getMessage('estimatedRemainingDuration')}<br>
+                  <li>{estimatedRemainingDuration}</li>
+              </p>
+          {/if}
+
           <p
             style="margin-bottom: 0.25rem;"
           >{getMessage('timeSavedPercentage')}<br>


### PR DESCRIPTION
This PR adds the "show estimated remaining video duration" (https://github.com/WofWca/jumpcutter/issues/177) feature to the time saved element tooltip and removes the timeSavedOnlyOneNumberIsShown logic since there will always be at least two items shown.

The "estimatedRemainingDuration" entry was added to the en translation messages for the screenshot below.
![image](https://github.com/user-attachments/assets/f42fbad4-6cf2-4b67-b227-1f8bc8de7588)

This is my first PR to a real project, so apologies if I didn't understand something correctly. Thanks in advance!
