### PR TITLE
WIP: feat: add "Time you will have saved on this video"

### DIFF
--- a/src/entry-points/content/AllMediaElementsController.ts
+++ b/src/entry-points/content/AllMediaElementsController.ts
@@ -63,6 +63,11 @@ export type TelemetryMessage =
      * Remember that this could be `Infinity` for live streams,
      * and if `.duration` is otherwise unknown.
      */
+    elementIntrinsicDuration: number,
+    /**
+     * This could also be `Infinity`
+     * @see {@linkcode elementIntrinsicDuration}.
+     */
     elementRemainingIntrinsicDuration: number,
   };
 
@@ -348,6 +353,7 @@ export default class AllMediaElementsController {
             elementCurrentSrc: elementLikelyCorsRestricted ? this.activeMediaElement.currentSrc : undefined,
             // TODO check if the map lookup is too slow to do it several times per second.
             createMediaElementSourceCalledForElement: !!mediaElementSourcesMap.get(this.activeMediaElement),
+            elementIntrinsicDuration: this.activeMediaElement.duration,
             elementRemainingIntrinsicDuration: this.activeMediaElement.duration - this.activeMediaElement.currentTime,
           };
           port.postMessage(telemetryMessage);

--- a/src/entry-points/popup/TimeSaved.svelte
+++ b/src/entry-points/popup/TimeSaved.svelte
@@ -21,6 +21,7 @@
   >;
   type RequiredTelemetry = Pick<
     TelemetryMessage,
+    | 'elementIntrinsicDuration'
     | 'elementRemainingIntrinsicDuration'
 
     | 'sessionTimeSaved'
@@ -167,6 +168,14 @@
     ? (r.elementRemainingIntrinsicDuration / timeSavedPlaybackRateEquivalents[0]) / settings.soundedSpeed
     : undefined;
 
+  $: estimatedTimeToBeSavedOnThisVideo =
+    settings &&
+    r?.elementIntrinsicDuration != undefined &&
+    r.elementIntrinsicDuration < Infinity &&
+    timeSavedComparedToSoundedSpeedFraction != undefined
+      ? (r.elementIntrinsicDuration / settings.soundedSpeed) * timeSavedComparedToSoundedSpeedFraction
+      : undefined;
+
   $: maybeOverTheLastLine =
     settings.timeSavedAveragingMethod === "exponential"
       ? `\n${getMessage(
@@ -201,6 +210,28 @@ especially accessibility-wise. -->
       <span>{getMessage("timeSaved")}.</span>
     </p>
 
+    
+    {#if
+      estimatedTimeToBeSavedOnThisVideo != undefined
+      // 10,000 hour sanity check
+      && estimatedTimeToBeSavedOnThisVideo < 10000 * 60 * 60
+    }
+      <p style="margin-bottom: 0.25rem;">
+      <!-- <p style="margin: 0.25rem 0;"> -->
+        <!-- TODO i18n -->
+        <!-- After watching this video, you will have saved<br /> -->
+        <!-- Time you will have saved after watching this video<br /> -->
+        {'Estimated time you will have saved on this video'}<br />
+        <!-- {'Time you have saved on this video'}<br /> -- when remaining duration is low -->
+        <!-- {'Time you will have saved on this video'}<br /> -->
+        <!-- {'Time you will have saved on this video'}<br /> -->
+        <span>{mmSs(estimatedTimeToBeSavedOnThisVideo)}</span>
+        <!-- TODO `estimatedTimeToBeSavedOnThisVideo` is dependent
+        on `soundedSpeed`, but the percentage does not,
+        so it might not make sense to users. -->
+        <span>({timeSavedComparedToSoundedSpeedPercent})</span>
+      </p>
+    {/if}
     <!-- Adding getMessage("overTheLast") here might be "correct",
     but it's perhaps confusing for just the "estimatedRemainingDuration" -->
     {#if
@@ -208,7 +239,7 @@ especially accessibility-wise. -->
       // 10,000 hour sanity check
       && estimatedRemainingDuration < 10000 * 60 * 60
     }
-      <p style="margin-bottom: 0.25rem;">
+      <p style="margin: 0.25rem 0;">
         {getMessage("estimatedRemainingDuration")}<br />
         {mmSs(estimatedRemainingDuration)}<br />
         <!-- Note that this doesn't update when the video is paused. -->


### PR DESCRIPTION
- [ ] Or is it bad?
	- [ ] Because it's not clear if this is real time or if it's how much of the video's intrinsic length is to be removed. Users might think that it's the latter, and will think that it's saving 2x less.
	- [ ] Maybe "how much you have already saved by now on this video" is just better. Because people can just take a look at v.currentTime and assume that the video lasted this much, and look at how much they have saved.
		- [ ] OTOH if they have been seeking, or
		- [ ] And anyways, "saving 17 minutes out of every hour" is juts better perhaps then.
